### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/flimble/surfaroundthecorner.png?label=ready&title=Ready)](https://waffle.io/flimble/surfaroundthecorner)
 [![Build Status](https://travis-ci.org/flimble/surfaroundthecorner.svg?branch=master)](https://travis-ci.org/flimble/surfaroundthecorner)
 [![Dependency Status](https://david-dm.org/flimble/surfaroundthecorner.svg)](https://david-dm.org/flimble/surfaroundthecorner)
 [![devDependency Status](https://david-dm.org/flimble/surfaroundthecorner/dev-status.svg)](https://david-dm.org/flimble/surfaroundthecorner#info=devDependencies)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/flimble/surfaroundthecorner

This was requested by a real person (user flimble) on waffle.io, we're not trying to spam you.
